### PR TITLE
🐛[fix] Update markdown check workflow paths

### DIFF
--- a/.github/workflows/markdown-check.yml
+++ b/.github/workflows/markdown-check.yml
@@ -3,15 +3,14 @@ name: 📝 Markdown Format Check
 on:
   pull_request:
     paths:
-      - 'docs/*.md'
       - 'README.md'
       - '.markdownlint.json'
       - '.markdown-link-check.json'
 
 # ========== 環境変数でMarkdownパスを定義 ==========
 env:
-  MD_PATHS: '"docs/*.md" "README.md"'
-  MD_GLOB_PATTERN: 'docs/*.md README.md'
+  MD_PATHS: '"README.md"'
+  MD_GLOB_PATTERN: 'README.md'
 
 jobs:
   markdown-lint:

--- a/.github/workflows/markdown-check.yml
+++ b/.github/workflows/markdown-check.yml
@@ -4,8 +4,6 @@ on:
   pull_request:
     paths:
       - 'README.md'
-      - '.markdownlint.json'
-      - '.markdown-link-check.json'
 
 # ========== 環境変数でMarkdownパスを定義 ==========
 env:


### PR DESCRIPTION
- Markdownチェックワークフローの対象ファイルを修正しました。
- `markdown-check.yml`内の`paths`セクションから`docs/*.md`を削除し、`README.md`のみを対象としました。
- 環境変数`MD_PATHS`を更新し、`README.md`のみに設定しました。
- 環境変数`MD_GLOB_PATTERN`も`README.md`に変更し、チェック対象を明確にしました。